### PR TITLE
feat: display card prices on search

### DIFF
--- a/app/static/js/dynamic_search.js
+++ b/app/static/js/dynamic_search.js
@@ -121,7 +121,7 @@ document.addEventListener('DOMContentLoaded', function() {
             
             // Fetch the USD price
             const usdPrice = card.prices?.usd;
-            let priceText = 'N/A';
+            let priceText = 'Price data not available';
 
             // Convert to AUD if USD price is available
             if (usdPrice) {


### PR DESCRIPTION
Closes #27 

### 📘 Summary

- This PR adds the ability to display Magic: The Gathering card prices in **AUD (Australian Dollars)** in the search results. 
- Prices are retrieved from the Scryfall API (`usd`) and converted client-side using the latest exchange rate from [[Open Exchange Rates API](https://open.er-api.com/v6/latest/USD) on page load
---

### ✅ What's Implemented

- Fetched `usd` prices using Scryfall API (`card.prices.usd`)
- Requested real-time USD → AUD exchange rate on page load
- Converted and displayed prices as `A$0.00` in each card result
- Fallback exchange rate (1.6) is used if API fails
- Gracefully handles missing price data with `"Price N/A"`

---

### 🐞 Known Issues

- Some cards (e.g. promos, tokens, unreleased sets) have no price info from Scryfall and will show `"N/A"`
  - Future improvement: Add tooltip or hover explanation for missing prices

---

### 🚀 Future Enhancements (Not in this PR)

- Show both AUD and original USD price (e.g. `A$1.50 (US$1.00)`)
- Cache exchange rate in `localStorage` for performance
- Allow user to select preferred currency (AUD, USD, EUR)

---

### 📷 Screenshots 
![{1280975C-D7D0-49D3-8D0B-A3D0C7ABD61C}](https://github.com/user-attachments/assets/565083e6-c9d0-413f-b5b1-e14a3aeaf048)

---
