### PR TITLE
Bug fix/dual cards not showing

### DIFF
--- a/app/static/css/cards.css
+++ b/app/static/css/cards.css
@@ -64,3 +64,12 @@
 .card-footer-btn:not(:hover) {
     transition: 0.3s ease;
 }
+
+.card-flip-animation {
+  transition: transform 0.6s;
+  transform-style: preserve-3d;
+}
+
+.flipping {
+  transform: rotateY(90deg);
+}

--- a/app/static/js/dynamic_search.js
+++ b/app/static/js/dynamic_search.js
@@ -141,20 +141,44 @@ document.addEventListener('DOMContentLoaded', function() {
             if (isDoubleFaced) {
                 // get the flip button as a var
                 const flipBtn = document.querySelector(`#flip-${card.id}`);
+                const imgElement = cardElement.querySelector('img');
+                
+                let isFlip = false;
+
+                // add animation to image
+                imgElement.classList.add('card-flip-animation');
 
                 // check if flip button of item is pressed - event listener
                 flipBtn.addEventListener('click', () => {
-                    if (cardElement.querySelector('img').getAttribute('data-flip') === '1') {
-                        // set the image to the other image
-                        cardElement.querySelector('img').src = card.card_faces[1].image_uris.normal;
+                    if (isFlip) return;
 
-                        // set the value of the data-flip attribute depending on the value of data-flip
-                        cardElement.querySelector('img').setAttribute('data-flip', '0');
+                    // animation initiate
+                    isFlip = true;
+                    imgElement.classList.add('flipping');
 
-                    } else if (cardElement.querySelector('img').getAttribute('data-flip') === '0') {
-                        cardElement.querySelector('img').src = card.card_faces[0].image_uris.normal;
-                        cardElement.querySelector('img').setAttribute('data-flip', '1');
-                    }
+                    // animation must complete before changing img
+                    setTimeout(() => {
+                        const img = cardElement.querySelector('img');
+                        const currFlip = cardElement.querySelector('img').getAttribute('data-flip');
+                        
+                        if (currFlip === '0') {
+                            // set the image to the other image
+                            img.src = card.card_faces[1].image_uris.normal || img.src;
+
+                            // set the value of the data-flip attribute depending on the value of data-flip
+                            img.setAttribute('data-flip', '1');
+
+                        } else if (currFlip === '1') {
+                            img.src = card.card_faces[0].image_uris.normal || img.src;
+                            img.setAttribute('data-flip', '1');
+                        }
+
+                        // Remove the flipping class after animation completes
+                        setTimeout(() => {
+                            imgElement.classList.remove('flipping');
+                            isFlip = false;
+                        }, 300); // Full animation duration
+                    }, 600); 
                 });
             }
         });


### PR DESCRIPTION
Closes #42 

**Current Behavior**:  
Dual-sided cards were not rendered correctly, showing as blank images because there was no logic to handle the display of both faces of these cards.

**Proposed Fix**:  
This update introduces a button that allows users to flip dual-sided cards after they have been rendered, allowing them to see both faces of the card. Additionally, if a card does not have a normal image URI (such as in the case of dual-faced cards), the first face of the card is displayed by default.

### Changes Made:
- Added functionality to check if a card is dual-faced and allow users to flip the card image.
- Implemented basic flip animation for dual-sided cards
- Ensured that if no normal image URI is available, the first face of the card will be displayed.