### PR TITLE
Improve share cards UI: carousel, buttons sync, modal logic fixes

### DIFF
--- a/app/static/css/share.css
+++ b/app/static/css/share.css
@@ -77,3 +77,80 @@
   width: 140px;
 }
 
+.snap-container {
+  scroll-snap-type: x mandatory;
+  gap: 1rem;
+}
+.snap-container::-webkit-scrollbar {
+  height: 8px;
+}
+.snap-container::-webkit-scrollbar-thumb {
+  background: rgba(255,255,255,0.3);
+  border-radius: 4px;
+}
+
+/* === Each selected‐card styling === */
+.selected-card {
+  flex: 0 0 120px;
+  scroll-snap-align: start;
+  background: #332940;
+  border-radius: 0.5rem;
+  padding: 0.5rem;
+  text-align: center;
+  position: relative;
+  transition: transform 0.2s, box-shadow 0.2s;
+}
+.selected-card:hover {
+  transform: translateY(-4px);
+  box-shadow: 0 4px 12px rgba(0,0,0,0.5);
+}
+.selected-card img {
+  width: 100%;
+  height: 80px;
+  object-fit: cover;
+  border-radius: 4px;
+}
+.selected-card .card-name {
+  font-size: 0.85rem;
+  color: #f5f5f5;
+  margin-top: 0.25rem;
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+.selected-card .remove-btn {
+  position: absolute;
+  top: 4px; right: 4px;
+  background: rgba(220,20,60,0.8);
+  border: none;
+  color: #fff;
+  width: 20px; height: 20px;
+  border-radius: 50%;
+  font-size: 0.75rem;
+  line-height: 1;
+  cursor: pointer;
+  opacity: 0.7;
+  transition: opacity 0.2s;
+}
+.selected-card .remove-btn:hover {
+  opacity: 1;
+}
+
+.selected-section {
+  padding: 2rem;
+}
+
+.selected-card {
+  flex: 0 0 auto;
+  width: 200px;
+}
+
+.selected-card img {
+  width: 100%;        
+  height: auto;
+  max-height: 400px;  
+}
+
+.snap-container {
+  padding-bottom: 1rem; 
+}

--- a/app/static/js/share.js
+++ b/app/static/js/share.js
@@ -1,30 +1,83 @@
+console.log('🔍 share.js loaded');
+
 document.addEventListener('DOMContentLoaded', () => {
-  const shareModalEl = document.getElementById('shareOptionsModal');
-  const shareModal   = new bootstrap.Modal(shareModalEl);
-  const closeBtn     = shareModalEl.querySelector('.btn-close');
+  console.log('📄 DOMContentLoaded');
+
+  // Modal
+  const shareModalEl  = document.getElementById('shareOptionsModal');
+  const shareModal    = new bootstrap.Modal(shareModalEl);
+  const closeModalBtn = shareModalEl.querySelector('.btn-close');
+
+  // Carousel / buttons
+  let selected       = [];
+  const carousel     = document.getElementById('selectedCarousel');
   const shareBtn     = document.getElementById('shareBtn');
-  const toggleBtn    = document.getElementById('toggleBtn');
-  const uploadedSearch = document.getElementById('uploadedSearch');
+  const clearAllBtn  = document.getElementById('clearAllBtn');
 
-  // Share button handler
-  shareBtn.addEventListener('click', async (event) => {
-    event.preventDefault();
+  console.log('shareBtn=', shareBtn, 'clearAllBtn=', clearAllBtn);
 
-    // Gather checked cards
-    const selected = Array.from(
-      document.querySelectorAll('.cards-grid .card-item input:checked')
-    ).map(cb => cb.closest('.card-item').dataset.cardId);
+  function renderSelected() {
+    carousel.innerHTML = '';
+    selected.forEach(c => {
+      const cardEl = document.createElement('div');
+      cardEl.className = 'selected-card';
+      cardEl.innerHTML = `
+        <button class="remove-btn">&times;</button>
+        <img src="${c.image_url}" alt="${c.name}">
+        <div class="card-name">${c.name}</div>
+      `;
+      cardEl.querySelector('.remove-btn').onclick = () => {
+        const gridCb = document.querySelector(
+          `.cards-grid .card-item[data-card-id="${c.id}"] input[type="checkbox"]`
+        );
+        if (gridCb) gridCb.checked = false;
+        selected = selected.filter(x => x.id !== c.id);
+        renderSelected();
+      };
+      carousel.append(cardEl);
+    });
+    document.getElementById('shareCount').textContent = selected.length;
+  }
 
+  clearAllBtn.addEventListener('click', () => {
+    console.log('🗑️ Clear All clicked');
+    document
+      .querySelectorAll('.cards-grid .card-item input[type="checkbox"]')
+      .forEach(cb => cb.checked = false);
+    selected = [];
+    renderSelected();
+  });
+
+  document.querySelectorAll('.cards-grid .card-item input[type="checkbox"]')
+    .forEach(cb => {
+      cb.addEventListener('change', e => {
+        const item = e.target.closest('.card-item');
+        const cardData = {
+          id:         item.dataset.cardId,
+          name:       item.querySelector('label').innerText.trim(),
+          image_url:  item.querySelector('img').src
+        };
+        if (e.target.checked) selected.push(cardData);
+        else selected = selected.filter(x => x.id !== cardData.id);
+        renderSelected();
+      });
+    });
+
+  renderSelected();
+
+  shareBtn.addEventListener('click', async ev => {
+    console.log('🖱️ shareBtn clicked; selected:', selected);
+    ev.preventDefault();
     if (selected.length === 0) {
-      alert("Please select at least one card.");
+      alert('Please select at least one card.');
       return;
     }
-
     try {
       const res = await fetch('/generate_share_link', {
         method: 'POST',
+        credentials: 'same-origin',
         headers: { 'Content-Type':'application/json' },
-        body: JSON.stringify({ card_ids: selected })
+        body: JSON.stringify({ card_ids: selected.map(c => c.id) })
       });
       const data = await res.json();
       if (!data.success) throw new Error(data.message || 'Error');
@@ -32,39 +85,35 @@ document.addEventListener('DOMContentLoaded', () => {
       const shareUrl    = data.share_url;
       const downloadUrl = `${window.location.origin}/download_shared/${data.link_id}`;
 
-      // Populate modal actions
-      document.getElementById('facebookShare').href =
+      shareModalEl.querySelector('#facebookShare').href =
         `https://www.facebook.com/sharer/sharer.php?u=${encodeURIComponent(shareUrl)}`;
-      document.getElementById('whatsappShare').href =
+      shareModalEl.querySelector('#whatsappShare').href =
         `https://api.whatsapp.com/send?text=${encodeURIComponent(shareUrl)}`;
-      document.getElementById('copyLinkBtn').onclick = () => {
+      shareModalEl.querySelector('#copyLinkBtn').onclick = () => {
         navigator.clipboard.writeText(shareUrl);
-        alert("Link copied!");
+        alert('Link copied!');
       };
-      document.getElementById('downloadBtn').onclick = () => {
+      shareModalEl.querySelector('#downloadBtn').onclick = () => {
         window.location.href = downloadUrl;
       };
 
       shareModal.show();
     } catch (err) {
       console.error(err);
-      alert("Failed to generate share link: " + err.message);
+      alert('Failed to generate share link: ' + err.message);
     }
   });
 
-  // Close-button handler (explicitly hide the modal)
-  closeBtn.addEventListener('click', () => {
-    shareModal.hide();
-  });
+  closeModalBtn.addEventListener('click', () => shareModal.hide());
 
-  // Sidebar toggle handler
+  // existing sidebar & search code follows...
+  const toggleBtn      = document.getElementById('toggleBtn');
+  const uploadedSearch = document.getElementById('uploadedSearch');
   if (toggleBtn) {
     toggleBtn.addEventListener('click', () => {
       document.getElementById('sidebar').classList.toggle('collapsed');
     });
   }
-
-  // Filter uploaded cards
   if (uploadedSearch) {
     uploadedSearch.addEventListener('input', () => {
       const term = uploadedSearch.value.trim().toLowerCase();

--- a/app/templates/share.html
+++ b/app/templates/share.html
@@ -6,87 +6,63 @@
 
 {% block content %}
 <div class="container mt-4">
-    <h1>Share Your Cards</h1>
+  <h1>Share Your Cards</h1>
+  <hr class="my-4">
 
-    <hr class="my-4">
+  <!-- Your Uploaded Cards -->
+  <h3>Your Uploaded Cards</h3>
+  <input type="text" id="uploadedSearch" class="form-control mb-3" placeholder="Filter your cards…">
+  <div class="cards-grid">
+    {% for card in user_cards %}
+    <div class="card-item" data-card-id="{{ card.id }}">
+      <input type="checkbox" class="form-check-input">
+      <img src="{{ card.image_url or url_for('static','images/placeholder.jpg') }}" alt="{{ card.name }}" width="120">
+      <label>{{ card.name }} ({{ card.rarity or 'Unknown' }})</label>
+    </div>
+    {% endfor %}
+  </div>
 
-    <!-- User Uploaded Cards -->
-    <h3>Your Uploaded Cards</h3>
-   
-    <!-- Filter input for uploaded cards -->
-    <input 
-    type="text" 
-    id="uploadedSearch" 
-    class="form-control mb-3" 
-    placeholder="Filter your cards…"
-    />
+  <hr class="my-4">
 
-    <div class="cards-grid">
-        {% for card in user_cards %}
-        <div class="card-item" data-card-id="{{ card.id }}">
-            <input type="checkbox" class="form-check-input">
-            <img 
-              src="{{ card.image_url or url_for('static','images/placeholder.jpg') }}" 
-              alt="{{ card.name }}" 
-              width="120"
-            >
-            <label>{{ card.name }} ({{ card.rarity or 'Unknown' }})</label>
+  <!-- New Selected-Cards Panel -->
+  <div class="selected-section p-3 bg-secondary rounded-3 mt-5">
+    <div class="d-flex justify-content-between align-items-center mb-3">
+      <h3 class="text-white mb-0">Selected Cards</h3>
+      <button id="clearAllBtn" class="btn btn-outline-light btn-sm">Clear All</button>
+    </div>
+
+    <div id="selectedCarousel" class="d-flex overflow-auto snap-container mb-3">
+      <!-- JS injects cards here -->
+    </div>
+
+    <div class="text-end">
+      <button id="shareBtn" class="btn btn-lg btn-primary">
+        <i class="fas fa-share me-1"></i>
+        Share <span id="shareCount" class="badge bg-light text-dark ms-1">0</span>
+      </button>
+    </div>
+  </div>
+
+  <!-- Share Options Modal -->
+  <div class="modal fade" id="shareOptionsModal">
+    <div class="modal-dialog modal-dialog-centered">
+      <div class="modal-content text-center">
+        <div class="modal-header">
+          <h5>Share Options</h5>
+          <button type="button" class="btn-close" id="closeModalBtn" data-bs-dismiss="modal" aria-label="Close"></button>
         </div>
-        {% endfor %}
-    </div>
-
-    <hr class="my-4">
-
-    <!-- Selected Cards -->
-    <h3>Selected Cards to Share</h3>
-    <ul id="selected-cards-list" class="list-group list-group-flush"></ul>
-
-    <!-- Share Button -->
-    <button class="btn btn-primary mt-4" id="shareBtn" >
-        <i class="fas fa-share"></i> Share Selected Cards
-    </button>
-
-    <!-- Upload Link -->
-    <div class="mt-4">
-        <a href="{{ url_for('main.upload_data_view') }}" class="btn btn-outline-info">
-            <i class="fas fa-upload"></i> Upload New Cards
-        </a>
-    </div>
-
-    <div class="mt-4">
-        <button id="uploadPromptBtn" class="btn btn-outline-info">
-            <i class="fas fa-upload"></i> Add New Cards
-        </button>
-    </div>
-
-    <!-- Share Modal -->
-    <div class="modal fade" id="shareOptionsModal">
-        <div class="modal-dialog modal-dialog-centered">
-            <div class="modal-content text-center">
-                <div class="modal-header">
-                    <h5>Share Options</h5>
-                        <button
-                            type="button"
-                            class="btn-close"
-                            id="closeModalBtn"
-                            aria-label="Close"
-                            data-bs-dismiss="modal"
-                        ></button>
-                    </div>
-                <div class="modal-body">
-                    <a id="facebookShare" class="btn btn-primary m-2">Facebook</a>
-                    <a id="whatsappShare" class="btn btn-success m-2">WhatsApp</a>
-                    <button id="copyLinkBtn" class="btn btn-warning m-2">Copy Link</button>
-                    <button id="downloadBtn" class="btn btn-info m-2">Download HTML</button>
-                </div>
-            </div>
+        <div class="modal-body">
+          <a id="facebookShare" class="btn btn-primary m-2">Facebook</a>
+          <a id="whatsappShare" class="btn btn-success m-2">WhatsApp</a>
+          <button id="copyLinkBtn" class="btn btn-warning m-2">Copy Link</button>
+          <button id="downloadBtn" class="btn btn-info m-2">Download HTML</button>
         </div>
+      </div>
     </div>
+  </div>
 </div>
 {% endblock %}
 
 {% block scripts %}
 <script src="{{ url_for('static', filename='js/share.js') }}"></script>
-
-
 {% endblock %}


### PR DESCRIPTION
### **This pull request refactors and enhances the “Share Cards” page by:**

- Replaced the old list-based selection and obsolete “Share Selected Cards” / “Upload New Cards” / “Add New Cards” buttons with a streamlined carousel-style selected-cards panel.
- Implemented a horizontal scroll-snap carousel (share.css) to preview selected cards, complete with “×” remove buttons and a live count badge.
- Synchronized checkbox states: clearing the carousel (via “Clear All” or individual removes) now also unchecks the corresponding grid checkboxes.
- Updated share.js to:
Manage the selected array and render the carousel dynamically.
Handle the Clear All, individual remove, and Share button events.
Include credentials: 'same-origin' in the fetch request so the login cookie is sent.
Show the Bootstrap modal with Facebook, WhatsApp, Copy Link, and Download buttons.
-Cleaned up share.html to only include the new carousel markup and removed deprecated buttons.
-Fixed Bootstrap loading issues by cleaning up base.html (moved to a feature branch; see separate PR).

### **All changes are contained in three files:**

-templates/share.html
-static/css/share.css
-static/js/share.js